### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: GitHub Pages
+permissions:
+  contents: read
 
 on:
   push:
@@ -8,6 +10,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04 # Set platform for runner
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/TIPPECC/tippecc.github.io/security/code-scanning/1](https://github.com/TIPPECC/tippecc.github.io/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the required permissions for the `GITHUB_TOKEN`. The best approach is to set the default permissions at the workflow level to `contents: read` (the minimal safe default), and then override the permissions for the `deploy` job to `contents: write`, since it needs to push to the `gh-pages` branch. This ensures that only the job that needs write access gets it, and all other jobs (if any are added in the future) will have read-only access by default.

**Steps:**
- Add a `permissions: contents: read` block at the top level of the workflow (after the `name` key).
- Add a `permissions: contents: write` block under the `deploy` job.

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
